### PR TITLE
Update repository name in docs-syncing workflow; revise README

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           source_file: "docs/"
           destination_repo: "josh-wong/josh-wong.github.io"
-          destination_folder: docs/cd-collection/
-          destination_branch_create: "cd-collection/update-docs"
+          destination_folder: docs/music-collection/
+          destination_branch_create: "music-collection/update-docs"
           user_name: "josh-wong"
           user_email: "joshuarwong@gmail.com"
-          commit_message: "AUTO: Sync cd-collection docs to personal site"
+          commit_message: "AUTO: Sync music-collection docs to personal site"
           use_rsync: rsync -avh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# CD collection
+# Music collection
 
-This repository contains a list of CDs that I've collected.
+This repository contains a list of CDs and vinyl records that I've collected.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,4 +6,4 @@ last reviewed: 2024-11-03
 title: CD collection
 ---
 
-The following is a list of CDs that I currently have in my collection, organized in alphanumeric order by artist.
+The following is a list of CDs and vinyl records that I currently have in my collection, organized in alphanumeric order by artist.


### PR DESCRIPTION
## Description

This PR changes the repository name from `cd-collection` to `music-collection` in the docs-syncing workflow and updates the README.

## Related issues and/or PRs

- https://github.com/josh-wong/josh-wong.github.io/pull/135

## Changes made

- Changed the repository name from `cd-collection` to `music-collection` in the `.github/workflows/sync-docs.yml` workflow.
- Made the README a bit more generic to include vinyl records in addition to CDs.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site. `N/A`
- [x] My changes generate no new warnings. `N/A`
