### PR TITLE
Add missing link to Miles Davis album

### DIFF
--- a/docs/m.mdx
+++ b/docs/m.mdx
@@ -102,7 +102,7 @@ title: M
 - **Released:** 2023
 - **Case:** Jewel case (box set)
 - **Obi:** Yes
-- **Additional details:** [Discogs]()
+- **Additional details:** [Discogs](https://www.discogs.com/release/28519066-Miles-Davis-The-Complete-Live-At-The-Plugged-Nickel-1965)
 
 ### Pangea
 


### PR DESCRIPTION
## Description

This PR adds a missing link to the Miles Davis album "The Complete Live At The Plugged Nickel 1965".

## Related issues and/or PRs

- #8

## Changes made

- Added a link for more details.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
