### PR TITLE
Add new CDs and vinyl record

### DIFF
--- a/docs/a.mdx
+++ b/docs/a.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-12-02
+last reviewed: 2024-12-08
 title: A
 ---
 
@@ -25,6 +25,17 @@ title: A
 - **Case:** Jewel case
 - **Obi:** Yes
 - **Additional details:** [Discogs](https://www.discogs.com/release/26858765-Alfa-Mist-Variables)
+
+## Alice Clark
+
+### Alice Clark
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 2017
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Discogs](https://www.discogs.com/release/13421614-Alice-Clark-Alice-Clark)
 
 ## Anderson .Paak
 

--- a/docs/a.mdx
+++ b/docs/a.mdx
@@ -2,11 +2,20 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-17
+last reviewed: 2024-12-02
 title: A
 ---
 
 ## Alfa Mist
+
+### Structuralism
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 2019
+- **Case:** Gatefold paper sleeve
+- **Obi:** No
+- **Additional details:** [Discogs](https://www.discogs.com/release/13747939-Alfa-Mist-Structuralism)
 
 ### Variables
 

--- a/docs/d.mdx
+++ b/docs/d.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-29
+last reviewed: 2024-12-04
 title: D
 ---
 
@@ -16,6 +16,17 @@ title: D
 - **Case:** Jewel case
 - **Obi:** No
 - **Additional details:** [Discogs](https://www.discogs.com/release/23427563-DAngelo-And-The-Vanguard-Black-Messiah)
+
+## Danny Brown
+
+### Old
+
+- **Format:** CD
+- **Country:** US
+- **Released:** 2013
+- **Case:** Jewel case
+- **Obi:** No
+- **Additional details:** [Discogs](https://www.discogs.com/release/4981831-Danny-Brown-Old)
 
 ## Dela
 

--- a/docs/g.mdx
+++ b/docs/g.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-29
+last reviewed: 2024-12-03
 title: G
 ---
 
@@ -18,6 +18,24 @@ title: G
 - **Additional details:** [Discogs](https://www.discogs.com/release/22335604-Ghostface-Killah-Ironman)
 
 ## Going Steady
+
+### Boys & Girls
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 1999
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Discogs](https://www.discogs.com/release/4449696-Going-Steady-Boys-Girls)
+
+### Boys & Girls
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 1999
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Discogs](https://www.discogs.com/release/4449696-Going-Steady-Boys-Girls)
 
 ### Sakura no Uta (さくらの唄)
 

--- a/docs/j.mdx
+++ b/docs/j.mdx
@@ -68,17 +68,6 @@ title: J
 - **Obi:** Yes
 - **Additional details:** [Discogs](https://www.discogs.com/release/25894933-Jeff-Parker-The-New-Breed)
 
-## Jimmy Haslip
-
-### ARC
-
-- **Format:** CD
-- **Country:** Japan
-- **Released:** 1993
-- **Case:** Jewel case
-- **Obi:** No
-- **Additional details:** [Tower Records Japan](https://tower.jp/item/531153)
-
 ## The Jimi Hendrix Experience 
 
 ### Are You Experienced
@@ -89,6 +78,17 @@ title: J
 - **Case:** Jewel case
 - **Obi:** No
 - **Additional details:** [Discogs](https://www.discogs.com/release/3796146-The-Jimi-Hendrix-Experience-Are-You-Experienced)
+
+## Jimmy Haslip
+
+### ARC
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 1993
+- **Case:** Jewel case
+- **Obi:** No
+- **Additional details:** [Tower Records Japan](https://tower.jp/item/531153)
 
 ## Jimmy McGriff
 

--- a/docs/j.mdx
+++ b/docs/j.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-12-03
+last reviewed: 2024-12-04
 title: J
 ---
 
@@ -89,6 +89,17 @@ title: J
 - **Case:** Jewel case
 - **Obi:** No
 - **Additional details:** [Discogs](https://www.discogs.com/release/3796146-The-Jimi-Hendrix-Experience-Are-You-Experienced)
+
+## Jimmy McGriff
+
+### Groove Grease
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 2013
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Discogs](https://www.discogs.com/release/12626122-Jimmy-McGriff-Groove-Grease)
 
 ## Joe
 

--- a/docs/j.mdx
+++ b/docs/j.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-29
+last reviewed: 2024-12-03
 title: J
 ---
 
@@ -45,6 +45,17 @@ title: J
 - **Case:** Jewel case
 - **Obi:** Yes
 - **Additional details:** [Discogs](https://www.discogs.com/release/26858765-Alfa-Mist-Variables)
+
+## Jaco Pastorius
+
+### Jaco Pastorius
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 2000
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Discogs](https://www.discogs.com/release/2806819-Jaco-Pastorius-Jaco-Pastorius)
 
 ## Jeff Parker
 

--- a/docs/l.mdx
+++ b/docs/l.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-08
+last reviewed: 2024-12-03
 title: L
 ---
 
@@ -27,3 +27,14 @@ title: L
 - **Case:** Jewel case
 - **Obi:** Yes
 - **Additional details:** [Discogs](https://www.discogs.com/release/13378671-Leon-Ware-Musical-Massage)
+
+## Luther Vandross
+
+### This Is Christmas
+
+- **Format:** CD
+- **Country:** Japan
+- **Released:** 1995
+- **Case:** Jewel case
+- **Obi:** Yes
+- **Additional details:** [Tower Records Japan](https://tower.jp/item/507428)

--- a/docs/n.mdx
+++ b/docs/n.mdx
@@ -2,7 +2,7 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-10
+last reviewed: 2024-12-04
 title: N
 ---
 
@@ -16,6 +16,15 @@ title: N
 - **Case:** Jewel case
 - **Obi:** No
 - **Additional details:** [Discogs](https://www.discogs.com/release/1958800-Nicolay-City-Lights-Volume-2-Shibuya)
+
+### City Lights Vol. 2: Shibuya
+
+- **Format:** Vinyl
+- **Country:** US
+- **Released:** 2024
+- **Case:** Cardboard
+- **Obi:** No
+- **Additional details:** [Discogs](https://www.discogs.com/release/31964951-Nicolay-City-Lights-Volume-2-Shibuya)
 
 ### Here
 

--- a/docs/t.mdx
+++ b/docs/t.mdx
@@ -2,9 +2,20 @@
 tags:
   - music
 date created: 2024-11-01
-last reviewed: 2024-11-24
+last reviewed: 2024-12-03
 title: T
 ---
+
+## Tanya Morgan
+
+### Moonlighting
+
+- **Format:** CD
+- **Country:** US
+- **Released:** 2006
+- **Case:** Jewel case
+- **Obi:** No
+- **Additional details:** [Discogs](https://www.discogs.com/release/663002-Tanya-Morgan-Moonlighting)
 
 ## Tatsuro Yamashita
 


### PR DESCRIPTION
## Description

This PR adds recently purchased CDs and vinyl records, and fixes the order of one entry since it was not in alphabetical order.

## Albums added

Added new CDs from the following artists:

- Alfa Mist
- Alice Clark
- Danny Brown
- Going Steady
- Jaco Pastorius
- Jimmy McGriff
- Luther Vandross
- Tanya Morgan

Added new vinyl records from the following artist:

- Nicolay